### PR TITLE
Updated jgettext version to 0.13

### DIFF
--- a/i18n-maven-plugin/src/main/java/net/jhorstmann/i18n/mojo/AbstractGettextMojo.java
+++ b/i18n-maven-plugin/src/main/java/net/jhorstmann/i18n/mojo/AbstractGettextMojo.java
@@ -5,6 +5,7 @@ import net.jhorstmann.i18n.tools.xgettext.MessageExtractor;
 import net.jhorstmann.i18n.tools.xgettext.MessageExtractorException;
 import net.jhorstmann.i18n.tools.xgettext.MessageFunction;
 import net.jhorstmann.i18n.xgettext.asm.AsmMessageExtractor;
+import net.jhorstmann.i18n.xgettext.web.WebMessageExtractor;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.maven.plugin.AbstractMojo;
@@ -145,7 +146,7 @@ abstract class AbstractGettextMojo extends AbstractMojo {
 
     List<MessageFunction> getELFunctions() {
         if (elFunctions == null) {
-            return AsmMessageExtractor.DEFAULT_MESSAGE_FUNCTIONS;
+            return WebMessageExtractor.DEFAULT_MESSAGE_FUNCTIONS;
         } else {
             int len = elFunctions.length;
             MessageFunction[] functions = new MessageFunction[len];

--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
             <dependency>
                 <groupId>org.fedorahosted.tennera</groupId>
                 <artifactId>jgettext</artifactId>
-                <version>0.6</version>
+                <version>0.13</version>
             </dependency>
             <dependency>
                 <groupId>org.fedorahosted.openprops</groupId>


### PR DESCRIPTION
Updated jgettext version to 0.13 (to auto-detect UTF-8 encoding in .po files). 
0.6 (currently in pom.xml) does not support UTF-8 unless you explicitly pass encoding to PoParser.parseCatalog.