### PR TITLE
Jdk11 support

### DIFF
--- a/i18n-gettext-tools/pom.xml
+++ b/i18n-gettext-tools/pom.xml
@@ -73,7 +73,23 @@
         </dependency>
         <dependency>
             <groupId>org.ow2.asm</groupId>
-            <artifactId>asm-all</artifactId>
+            <artifactId>asm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-tree</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-analysis</artifactId>
         </dependency>
         <dependency>
             <groupId>antlr</groupId>

--- a/i18n-gettext-tools/src/main/java/net/jhorstmann/i18n/tools/xgettext/MessageExtractorException.java
+++ b/i18n-gettext-tools/src/main/java/net/jhorstmann/i18n/tools/xgettext/MessageExtractorException.java
@@ -6,4 +6,8 @@ public class MessageExtractorException extends Exception {
         super(cause);
     }
     
+    public MessageExtractorException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
 }

--- a/i18n-maven-plugin/pom.xml
+++ b/i18n-maven-plugin/pom.xml
@@ -70,4 +70,17 @@
             <version>2.5</version>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>3.5.2</version>
+                <configuration>
+                    <goalPrefix>i18n</goalPrefix>
+                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/i18n-maven-plugin/src/main/java/net/jhorstmann/i18n/mojo/AbstractGettextMojo.java
+++ b/i18n-maven-plugin/src/main/java/net/jhorstmann/i18n/mojo/AbstractGettextMojo.java
@@ -30,6 +30,8 @@ import net.jhorstmann.i18n.tools.xgettext.MessageFunction;
 abstract class AbstractGettextMojo extends AbstractMojo {
 
     /**
+     * sourceDirectory
+     *
      * @parameter default-value="${project.build.sourceDirectory}"
      */
     File sourceDirectory;
@@ -62,11 +64,11 @@ abstract class AbstractGettextMojo extends AbstractMojo {
      */
     String[] poExcludes;
     /**
-     * @parameter default-value="${project.basedir}/src/main/po/keys.pot"
+     *  @parameter default-value="${project.basedir}/src/main/po/keys.pot"
      */
     File keysFile;
     /**
-     * @parameter default-value="${false}" expression="${gettext.update}"
+     * @parameter default-value="${false}" property="gettext.update"
      */
     boolean update;
     /**
@@ -82,36 +84,41 @@ abstract class AbstractGettextMojo extends AbstractMojo {
     /**
      * Report source-references
      *
-     * @parameter expression="${srcRefPaths}" default-value="true"
+     * @parameter property="srcRefPaths" default-value="true"
      */
     protected boolean srcRefPaths;
 
     /**
      * Skip this mojo.
      *
-     * @parameter expression="${skip}" default-value="false"
+     * @parameter property="skip" default-value="false"
      */
     protected boolean skip;
 
     /**
-     * @description E-Mail-address for message-bugs
-     * @parameter expression="${msgidBugsAddress}"
+     * E-Mail-address for message-bugs
+     *
+     * @parameter property="msgidBugsAddress"
      */
     protected String msgidBugsAddress;
 
     /**
-     * @description Name of the project/package
-     * @parameter expression="${pkgName}" default-value="${project.artifactId}"
+     * Name of the project/package
+     *
+     * @parameter property="pkgName" default-value="${project.artifactId}"
      */
     protected String pkgName;
 
     /**
-     * @description Version of the project/package
-     * @parameter expression="${pkgVersion}" default-value="${project.version}"
+     * Version of the project/package
+     *
+     * @parameter property="pkgVersion" default-value="${project.version}"
      */
     protected String pkgVersion;
 
-    /** @parameter default-value="${project}" */
+    /**
+     * @parameter default-value="${project}"
+     */
     protected org.apache.maven.project.MavenProject mavenProject;
 
     /**
@@ -120,7 +127,9 @@ abstract class AbstractGettextMojo extends AbstractMojo {
     protected File projectRoot;
 
     // Injection of the eclipse-buildcontext for m2e-compatibility
-    /** @component */
+    /**
+     * @component
+     **/
     protected BuildContext buildContext;
 
     AbstractGettextMojo() {

--- a/i18n-maven-plugin/src/main/java/net/jhorstmann/i18n/mojo/DistMojo.java
+++ b/i18n-maven-plugin/src/main/java/net/jhorstmann/i18n/mojo/DistMojo.java
@@ -38,7 +38,9 @@ public class DistMojo extends AbstractGettextMojo {
      */
     protected String sourceLocale;
 
-    /** @parameter default-value="${project}" */
+    /**
+     * @parameter default-value="${project}"
+     * */
     private org.apache.maven.project.MavenProject mavenProject;
 
     private static String getLocale(File file) {

--- a/i18n-maven-plugin/src/main/java/net/jhorstmann/i18n/mojo/WebappGettextMojo.java
+++ b/i18n-maven-plugin/src/main/java/net/jhorstmann/i18n/mojo/WebappGettextMojo.java
@@ -15,7 +15,7 @@ public class WebappGettextMojo extends AbstractGettextMojo {
     /**
      * Relativize the path for source-references to the project-root.
      * 
-     * @parameter expression="${relativizeSrcRefPaths}" default-value="false"
+     * @parameter property="relativizeSrcRefPaths" default-value="false"
      */
     protected boolean relativizeSrcRefPaths;
 

--- a/i18n-xgettext-asm/pom.xml
+++ b/i18n-xgettext-asm/pom.xml
@@ -31,7 +31,11 @@
         </dependency>
         <dependency>
             <groupId>org.ow2.asm</groupId>
-            <artifactId>asm-all</artifactId>
+            <artifactId>asm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-commons</artifactId>
         </dependency>
         <dependency>
             <groupId>org.fedorahosted.tennera</groupId>

--- a/i18n-xgettext-web/src/main/java/net/jhorstmann/i18n/xgettext/web/WebMessageExtractor.java
+++ b/i18n-xgettext-web/src/main/java/net/jhorstmann/i18n/xgettext/web/WebMessageExtractor.java
@@ -108,9 +108,9 @@ public class WebMessageExtractor extends AbstractExtractorHandler implements Mes
         try {
             xmlreader.parse(input);
         } catch (SAXException ex) {
-            throw new MessageExtractorException(ex);
+            throw new MessageExtractorException(input.getSystemId(), ex);
         } catch (ELException ex) {
-            throw new MessageExtractorException(ex);
+            throw new MessageExtractorException(input.getSystemId(), ex);
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <antlr.version>2.7.7</antlr.version>
         <jsf.version>2.1.2</jsf.version>
-        <project.build.javaVersion>1.6</project.build.javaVersion>
+        <project.build.javaVersion>1.8</project.build.javaVersion>
+        <asm.version>7.0</asm.version>
     </properties>
     <build>
         <pluginManagement>
@@ -275,8 +276,28 @@
             </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>
-                <artifactId>asm-all</artifactId>
-                <version>5.0.4</version>
+                <artifactId>asm</artifactId>
+                <version>${asm.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-commons</artifactId>
+                <version>${asm.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-util</artifactId>
+                <version>${asm.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-tree</artifactId>
+                <version>${asm.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-analysis</artifactId>
+                <version>${asm.version}</version>
             </dependency>
             <dependency>
                 <groupId>antlr</groupId>


### PR DESCRIPTION
Three changes:
Building using JDK8.
Upgrades asm to version 7.0, being able to read classes built in JDK11.
Slightly better stacktrace from MessageExtractorException